### PR TITLE
[feature/6-stores-fix] 사업자 정보 조회 API path variable 추가 및 판매자 프로필 조회 API 분리

### DIFF
--- a/src/main/java/com/codepatissier/keki/store/controller/StoreController.java
+++ b/src/main/java/com/codepatissier/keki/store/controller/StoreController.java
@@ -2,8 +2,9 @@ package com.codepatissier.keki.store.controller;
 
 import com.codepatissier.keki.common.BaseException;
 import com.codepatissier.keki.common.BaseResponse;
-import com.codepatissier.keki.store.dto.GetProfileRes;
+import com.codepatissier.keki.store.dto.GetMyPageStoreProfileRes;
 import com.codepatissier.keki.store.dto.GetStoreInfoRes;
+import com.codepatissier.keki.store.dto.GetStoreProfileRes;
 import com.codepatissier.keki.store.dto.PostStoreReq;
 import com.codepatissier.keki.store.service.StoreService;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -33,7 +34,7 @@ public class StoreController {
     @PostMapping("/signup")
     public BaseResponse<String> createSeller(@Valid @RequestBody PostStoreReq postStoreReq) {
         try {
-            storeService.createSeller(postStoreReq);
+            storeService.createSeller(authService.getUserIdx(), postStoreReq);
             return new BaseResponse<>(SUCCESS);
         } catch (BaseException e) {
             return new BaseResponse<>(e.getStatus());
@@ -42,14 +43,14 @@ public class StoreController {
 
     /**
      * 판매자 사업자 정보 조회
-     * [GET] /stores/store-info
+     * [GET] /stores/store-info/:storeIdx
      * @return businessName, brandName, businessAddress, businessNumber
      */
     @ResponseBody
-    @GetMapping("/store-info")
-    public BaseResponse<GetStoreInfoRes> getStoreInfo() {
+    @GetMapping("/store-info/{storeIdx}")
+    public BaseResponse<GetStoreInfoRes> getStoreInfo(@PathVariable("storeIdx") Long storeIdx) {
         try {
-            GetStoreInfoRes getStoreInfoRes = storeService.getStoreInfo(authService.getUserIdx());
+            GetStoreInfoRes getStoreInfoRes = storeService.getStoreInfo(storeIdx);
             return new BaseResponse<>(getStoreInfoRes);
         } catch (BaseException e) {
             return new BaseResponse<>(e.getStatus());
@@ -58,14 +59,32 @@ public class StoreController {
 
     /**
      * 판매자 프로필 조회
+     * [GET] /stores/profile/:storeIdx
+     * 가게 메인 화면
+     * @return 가게 사진, 이름, 소개
+     */
+    @ResponseBody
+    @GetMapping("/profile/{storeIdx}")
+    public BaseResponse<GetStoreProfileRes> getStoreProfile(@PathVariable("storeIdx") Long storeIdx) {
+        try {
+            return new BaseResponse<>(storeService.getStoreProfile(storeIdx));
+        } catch (BaseException e) {
+            return new BaseResponse<>(e.getStatus());
+        }
+    }
+
+    /**
+     * 판매자 프로필 조회
      * [GET] /stores/profile
+     * 마이페이지 판매자 프로필 편집
+     * @return 가게 사진, 이름, 주소, 소개, 주문 링크
      */
     @ResponseBody
     @GetMapping("/profile")
-    public BaseResponse<GetProfileRes> getStoreProfile() {
+    public BaseResponse<GetMyPageStoreProfileRes> getStoreProfileMyPage() {
         try {
-            GetProfileRes getProfileRes = storeService.getStoreProfile(authService.getUserIdx());
-            return new BaseResponse<>(getProfileRes);
+            GetMyPageStoreProfileRes getMyPageStoreProfileRes = storeService.getStoreProfileMyPage(authService.getUserIdx());
+            return new BaseResponse<>(getMyPageStoreProfileRes);
         } catch (BaseException e) {
             return new BaseResponse<>(e.getStatus());
         }

--- a/src/main/java/com/codepatissier/keki/store/dto/GetMyPageStoreProfileRes.java
+++ b/src/main/java/com/codepatissier/keki/store/dto/GetMyPageStoreProfileRes.java
@@ -1,0 +1,16 @@
+package com.codepatissier.keki.store.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class GetMyPageStoreProfileRes {
+    private String storeImgUrl;
+    private String nickname;
+    private String address;
+    private String introduction;
+    private String orderUrl;
+}

--- a/src/main/java/com/codepatissier/keki/store/dto/GetStoreProfileRes.java
+++ b/src/main/java/com/codepatissier/keki/store/dto/GetStoreProfileRes.java
@@ -7,7 +7,7 @@ import lombok.NoArgsConstructor;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
-public class GetProfileRes {
+public class GetStoreProfileRes {
     private String nickname;
     private String storeImgUrl;
     private String introduction;

--- a/src/main/java/com/codepatissier/keki/store/repository/StoreRepository.java
+++ b/src/main/java/com/codepatissier/keki/store/repository/StoreRepository.java
@@ -1,9 +1,11 @@
 package com.codepatissier.keki.store.repository;
 
 import com.codepatissier.keki.store.entity.Store;
+import com.codepatissier.keki.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface StoreRepository extends JpaRepository<Store, Long> {
+    Store findByUser(User user);
 }


### PR DESCRIPTION
## 📚 이슈 번호
#6

## 💬 기타 사항
- 사업자 정보 조회 API에 token 사용을 없애고 path variable로 storeIdx 전달 받는 것으로 수정
- 판매자 프로필 조회 API를 가게 메인 페이지/마이 페이지 판매자 프로필 편집 두 가지로 분리
