### PR TITLE
[feature/8-users-fix] 액세스 토큰 만료 시간 임시 수정

### DIFF
--- a/src/main/java/com/codepatissier/keki/user/service/AuthService.java
+++ b/src/main/java/com/codepatissier/keki/user/service/AuthService.java
@@ -27,7 +27,8 @@ import static com.codepatissier.keki.common.BaseResponseStatus.NULL_TOKEN;
 @RequiredArgsConstructor
 public class AuthService {
 
-    private final int accessTokenExpiryDate = 3600000;
+    // TODO 액세스토큰 만료시간 추후 줄이기 (테스트 위해 임시 설정)
+    private final int accessTokenExpiryDate = 604800000;
     private final int refreshTokenExpiryDate = 604800000;
 
     @Value("${auth.key}")


### PR DESCRIPTION
## 📚 이슈 번호
#8 

## 💬 기타 사항
- 로그인 구현 전까지 다른 API 테스트를 위해 액세스 토큰 만료 시간을 임시로 늘렸습니다
