### PR TITLE
[feature/6-stores] 판매자 프로필 수정 API empty string, 공백 예외 처리 & 판매자 회원가입, 프로필 수정 API empty string을 null로 변환해 DB 저장

### DIFF
--- a/src/main/java/com/codepatissier/keki/common/BaseResponseStatus.java
+++ b/src/main/java/com/codepatissier/keki/common/BaseResponseStatus.java
@@ -50,6 +50,13 @@ public enum BaseResponseStatus {
 
     // stores(3100~3199)
     INVALID_STORE_IDX(false, 3100, "존재하지 않는 스토어입니다."),
+    NULL_ADDRESS(false, 3101, "주소를 입력해주세요."),
+    NULL_ORDER_URL(false, 3102, "주문 링크를 입력해주세요."),
+    NULL_BUSINESS_NAME(false, 3103, "대표자명을 입력해주세요."),
+    NULL_BRAND_NAME(false, 3104, "상호명을 입력해주세요."),
+    NULL_BUSINESS_ADDRESS(false, 3105, "사업자 주소를 입력해주세요."),
+    NULL_BUSINESS_NUMBER(false, 3106, "사업자 번호를 입력해주세요."),
+    NULL_NICKNAME(false, 3107, "가게 이름을 입력해주세요."),
 
     // posts(3200~3299)
     INVALID_POST_IDX(false, 3200, "존재하지 않는 피드입니다."),

--- a/src/main/java/com/codepatissier/keki/common/EmptyStringToNullConverter.java
+++ b/src/main/java/com/codepatissier/keki/common/EmptyStringToNullConverter.java
@@ -1,0 +1,17 @@
+package com.codepatissier.keki.common;
+
+import javax.persistence.AttributeConverter;
+import javax.persistence.Converter;
+
+@Converter(autoApply = true)
+public class EmptyStringToNullConverter implements AttributeConverter<String, String> {
+    @Override
+    public String convertToDatabaseColumn(String string) {
+        return "".equals(string) ? null : string;
+    }
+
+    @Override
+    public String convertToEntityAttribute(String dbData) {
+        return dbData;
+    }
+}

--- a/src/main/java/com/codepatissier/keki/store/controller/StoreController.java
+++ b/src/main/java/com/codepatissier/keki/store/controller/StoreController.java
@@ -24,7 +24,7 @@ public class StoreController {
     private final AuthService authService;
 
     /**
-     * 판매자 회원가입
+     * [판매자] 회원가입
      * [POST] /stores/signup
      */
     @ResponseBody
@@ -71,7 +71,7 @@ public class StoreController {
     }
 
     /**
-     * 판매자 프로필 조회
+     * [판매자] 프로필 조회
      * [GET] /stores/profile
      * 마이페이지 판매자 프로필 편집
      * @return 가게 사진, 이름, 주소, 소개, 주문 링크, 사업자 정보, 이메일
@@ -88,7 +88,7 @@ public class StoreController {
     }
 
     /**
-     * 판매자 프로필 정보 수정
+     * [판매자] 프로필 정보 수정
      * PATCH /stores/profile
      */
     @ResponseBody

--- a/src/main/java/com/codepatissier/keki/store/dto/PatchProfileReq.java
+++ b/src/main/java/com/codepatissier/keki/store/dto/PatchProfileReq.java
@@ -1,16 +1,21 @@
 package com.codepatissier.keki.store.dto;
 
+import com.codepatissier.keki.common.EmptyStringToNullConverter;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+
+import javax.persistence.Convert;
 
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 public class PatchProfileReq {
+    @Convert(converter = EmptyStringToNullConverter.class)
     private String storeImgUrl;
     private String nickname;
     private String address;
+    @Convert(converter = EmptyStringToNullConverter.class)
     private String introduction;
     private String orderUrl;
     private String businessName;

--- a/src/main/java/com/codepatissier/keki/store/dto/PostStoreReq.java
+++ b/src/main/java/com/codepatissier/keki/store/dto/PostStoreReq.java
@@ -1,9 +1,11 @@
 package com.codepatissier.keki.store.dto;
 
+import com.codepatissier.keki.common.EmptyStringToNullConverter;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import javax.persistence.Convert;
 import javax.validation.constraints.NotBlank;
 
 @Data
@@ -12,9 +14,11 @@ import javax.validation.constraints.NotBlank;
 public class PostStoreReq {
     @NotBlank
     private String nickname;
+    @Convert(converter = EmptyStringToNullConverter.class)
     private String storeImgUrl;
     @NotBlank
     private String address;
+    @Convert(converter = EmptyStringToNullConverter.class)
     private String introduction;
     @NotBlank
     private String orderUrl;

--- a/src/main/java/com/codepatissier/keki/store/entity/Store.java
+++ b/src/main/java/com/codepatissier/keki/store/entity/Store.java
@@ -8,7 +8,7 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.DynamicInsert;
 
 import javax.persistence.*;
-import javax.validation.constraints.NotNull;
+import javax.validation.constraints.NotBlank;
 
 @Getter
 @Entity
@@ -23,14 +23,14 @@ public class Store extends BaseEntity {
     @JoinColumn(name = "userIdx")
     private User user;
 
-    @NotNull
+    @NotBlank
     @Column(length = 100)
     private String address;
 
     @Column(length = 200)
     private String introduction;
 
-    @NotNull
+    @NotBlank
     @Column
     private String orderUrl;
 
@@ -38,22 +38,22 @@ public class Store extends BaseEntity {
      * 사업자 정보
      */
     // 대표자명
-    @NotNull
+    @NotBlank
     @Column(length = 50)
     private String businessName;
 
     // 가게 이름
-    @NotNull
+    @NotBlank
     @Column(length = 50)
     private String brandName;
 
     // 사업자 주소
-    @NotNull
+    @NotBlank
     @Column(length = 100)
     private String businessAddress;
 
     // 사업자 등록번호
-    @NotNull
+    @NotBlank
     @Column(length = 100)
     private String businessNumber;
 

--- a/src/main/java/com/codepatissier/keki/store/service/StoreService.java
+++ b/src/main/java/com/codepatissier/keki/store/service/StoreService.java
@@ -87,7 +87,8 @@ public class StoreService {
         }
     }
 
-    // 가게 프로필 수정 (가게 사진, 이름, 주소, 소개, 주문 링크)
+    // 가게 프로필 수정
+    // 가게 사진, 이름, 주소, 소개, 주문 링크, 사업자 정보
     @Transactional(rollbackFor = Exception.class)
     public void modifyProfile(Long userIdx, PatchProfileReq patchProfileReq) throws BaseException {
         try {
@@ -98,18 +99,51 @@ public class StoreService {
                 user.setProfileImg(patchProfileReq.getStoreImgUrl());
                 store.setUser(user);
             }
-            if (patchProfileReq.getNickname() != null) {
-                user.setNickname(patchProfileReq.getNickname());
-                store.setUser(user);
-            }
-            if (patchProfileReq.getAddress() != null) store.setAddress(patchProfileReq.getAddress());
-            if (patchProfileReq.getIntroduction() != null) store.setIntroduction(patchProfileReq.getIntroduction());
-            if (patchProfileReq.getOrderUrl() != null) store.setOrderUrl(patchProfileReq.getOrderUrl());
-            if (patchProfileReq.getBusinessName() != null) store.setBusinessName(patchProfileReq.getBusinessName());
-            if (patchProfileReq.getBrandName() != null) store.setBrandName(patchProfileReq.getBrandName());
-            if (patchProfileReq.getBusinessAddress() != null) store.setBusinessAddress(patchProfileReq.getBusinessAddress());
-            if (patchProfileReq.getBusinessNumber() != null) store.setBusinessNumber(patchProfileReq.getBusinessNumber());
 
+            if (patchProfileReq.getNickname() != null) { // TODO User entity nickname @NOTBLANK 처리
+                if (!patchProfileReq.getNickname().equals("") && !patchProfileReq.getNickname().equals(" ")) {
+                    user.setNickname(patchProfileReq.getNickname());
+                    store.setUser(user);
+                } else throw new BaseException(NULL_NICKNAME);
+            }
+
+            if (patchProfileReq.getAddress() != null) {
+                if (!patchProfileReq.getAddress().equals("") && !patchProfileReq.getAddress().equals(" "))
+                    store.setAddress(patchProfileReq.getAddress());
+                else throw new BaseException(NULL_ADDRESS);
+            }
+
+            if (patchProfileReq.getIntroduction() != null) store.setIntroduction(patchProfileReq.getIntroduction());
+
+            if (patchProfileReq.getOrderUrl() != null) {
+                if (!patchProfileReq.getOrderUrl().equals("") && !patchProfileReq.getOrderUrl().equals(" "))
+                    store.setOrderUrl(patchProfileReq.getOrderUrl());
+                else throw new BaseException(NULL_ORDER_URL);
+            }
+
+            if (patchProfileReq.getBusinessName() != null) {
+                if (!patchProfileReq.getBusinessName().equals("") && !patchProfileReq.getBusinessName().equals(" "))
+                    store.setBusinessName(patchProfileReq.getBusinessName());
+                else throw new BaseException(NULL_BUSINESS_NAME);
+            }
+
+            if (patchProfileReq.getBrandName() != null) {
+                if (!patchProfileReq.getBrandName().equals("") && !patchProfileReq.getBrandName().equals(" "))
+                    store.setBrandName(patchProfileReq.getBrandName());
+                else throw new BaseException(NULL_BRAND_NAME);
+            }
+
+            if (patchProfileReq.getBusinessAddress() != null) {
+                if (!patchProfileReq.getBusinessAddress().equals("") && !patchProfileReq.getBusinessAddress().equals(" "))
+                    store.setBusinessAddress(patchProfileReq.getBusinessAddress());
+                else throw new BaseException(NULL_BUSINESS_ADDRESS);
+            }
+
+            if (patchProfileReq.getBusinessNumber() != null) {
+                if (!patchProfileReq.getBusinessNumber().equals("") && !patchProfileReq.getBusinessNumber().equals(" "))
+                    store.setBusinessNumber(patchProfileReq.getBusinessNumber());
+                else throw new BaseException(NULL_BUSINESS_NUMBER);
+            }
             userRepository.save(user);
             storeRepository.save(store);
         } catch (BaseException e) {


### PR DESCRIPTION
## 📚 이슈 번호
#6

## 💬 기타 사항
1.  판매자 회원가입 API
- null값일 수 없는 컬럼: @NotBlank annotation 처리
- null값이어도 되는 컬럼: Request로 empty string이 들어올 경우 null로 변환해 DB 저장
<br>

2. 판매자 프로필 수정 API
- null값일 수 없는 컬럼: 수정하지 않는 값은 null값으로 들어오므로 @NotBlank 처리를 할 수 없기 때문에 Service에서 empty string, 
  공백 문자 예외처리 (null값으로 들어오면 DB에 아무 변화X)
- null값이어도 되는 컬럼: empty string으로 들어온 경우 null로 변환해 DB 저장