### PR TITLE
[feature/8-users-auth] 소셜 로그인 API 로직 서버와 클라이언트 담당 분리

### DIFF
--- a/src/main/java/com/codepatissier/keki/common/BaseResponseStatus.java
+++ b/src/main/java/com/codepatissier/keki/common/BaseResponseStatus.java
@@ -15,6 +15,9 @@ public enum BaseResponseStatus {
      */
     // users(2000~2099)
      NULL_TOKEN(false, 2000, "토큰 값을 입력해주세요."),
+    NULL_EMAIL(false, 2001, "이메일을 입력해주세요."),
+    NULL_PROVIDER(false, 2002, "소셜 이름을 입력해주세요."),
+    INVALID_PROVIDER(false, 2003, "잘못된 소셜 이름입니다."),
 
     // stores(2100~2199)
 

--- a/src/main/java/com/codepatissier/keki/user/controller/UserController.java
+++ b/src/main/java/com/codepatissier/keki/user/controller/UserController.java
@@ -2,22 +2,16 @@ package com.codepatissier.keki.user.controller;
 
 import com.codepatissier.keki.common.BaseException;
 import com.codepatissier.keki.common.BaseResponse;
-import com.codepatissier.keki.common.BaseResponseStatus;
-import com.codepatissier.keki.user.dto.PatchProfileReq;
-import com.codepatissier.keki.user.dto.PostCustomerReq;
-import com.codepatissier.keki.user.dto.PostNicknameReq;
-import com.codepatissier.keki.user.dto.PostUserReq;
+import com.codepatissier.keki.user.dto.*;
 import com.codepatissier.keki.user.service.*;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.ui.Model;
 import com.codepatissier.keki.user.service.AuthService;
 import org.springframework.web.bind.annotation.*;
 import javax.servlet.http.HttpSession;
-import java.net.URISyntaxException;
 
-import static com.codepatissier.keki.common.BaseResponseStatus.SUCCESS;
+import static com.codepatissier.keki.common.BaseResponseStatus.*;
 
 @SecurityRequirement(name = "Bearer")
 @Tag(name = "users", description = "구매자 API")
@@ -38,32 +32,11 @@ public class UserController {
         return new BaseResponse<>(httpHeaders);
     }
 
-    // 카카오 로그인 콜백
-    @ResponseBody
-    @GetMapping("/callback/kakao")
-    public BaseResponse<?> kakaoCallback(@RequestParam String code) {
-        try{
-            return new BaseResponse<>(userService.kakaoLogin(code));
-        }catch (BaseException e){
-            return new BaseResponse<>(e.getStatus());
-        }
-    }
-
     // 네이버 로그인 url 요청
     @GetMapping("/login/naver")
     public BaseResponse<?> login(HttpSession session) {
         String httpHeaders = naverService.getAuthorizationUrl(session);
         return new BaseResponse<>(httpHeaders);
-    }
-
-    // 네이버 로그인 콜백
-    @GetMapping("/callback/naver")
-    public BaseResponse<?> naverCallback(@RequestParam String code, HttpSession session) {
-        try{
-            return new BaseResponse<>(userService.naverLogin(code, session));
-        }catch (BaseException e){
-            return new BaseResponse<>(e.getStatus());
-        }
     }
 
     // 구글 로그인 url 요청
@@ -73,29 +46,20 @@ public class UserController {
         return new BaseResponse<>(httpHeaders);
     }
 
-    // 구글 로그인 콜백
-    @GetMapping("/callback/google")
-    public BaseResponse<?> googleCallback(@RequestParam String code, HttpSession session) {
-        try{
-            return new BaseResponse<>(userService.googleLogin(code, session));
-        }catch (BaseException e){
-            return new BaseResponse<>(e.getStatus());
-        }
-    }
-
-    // 프론트로부터 이메일만 받아오는 경우 로그인
+    // 소셜 로그인/회원가입
     @ResponseBody
-    @PostMapping("/signin")
+    @PostMapping("/login")
     public BaseResponse<?> login(@RequestBody PostUserReq postUserReq) {
         try{
-            return new BaseResponse<>(userService.signinEmail(postUserReq));
+            if(postUserReq.getEmail() == null) throw new BaseException(NULL_EMAIL);
+            if(postUserReq.getProvider() == null) throw new BaseException(NULL_PROVIDER);
+            return new BaseResponse<>(userService.login(postUserReq.getEmail(), postUserReq.getProvider()));
         }catch (BaseException e){
             return new BaseResponse<>(e.getStatus());
         }
-
     }
 
-    // 프론트로부터 이메일만 받아오는 경우 구매자 회원가입
+    // 구매자 회원가입
     @ResponseBody
     @PostMapping("/signup")
     public BaseResponse<?> signup(@RequestBody PostCustomerReq postCustomerReq) {
@@ -104,7 +68,6 @@ public class UserController {
         }catch (BaseException e){
             return new BaseResponse<>(e.getStatus());
         }
-
     }
 
     // 닉네임 중복 확인

--- a/src/main/java/com/codepatissier/keki/user/dto/PostUserReq.java
+++ b/src/main/java/com/codepatissier/keki/user/dto/PostUserReq.java
@@ -2,7 +2,12 @@ package com.codepatissier.keki.user.dto;
 
 import lombok.Getter;
 
+import javax.validation.constraints.NotBlank;
+
 @Getter
 public class PostUserReq {
+    @NotBlank
     private String email;
+    @NotBlank
+    private String provider;
 }

--- a/src/main/java/com/codepatissier/keki/user/entity/Provider.java
+++ b/src/main/java/com/codepatissier/keki/user/entity/Provider.java
@@ -2,7 +2,25 @@ package com.codepatissier.keki.user.entity;
 
 import lombok.Getter;
 
+import java.util.Arrays;
+
 @Getter
 public enum Provider {
-    GOOGLE, KAKAO, NAVER, ANONYMOUS
-}
+    KAKAO(1, "카카오"),
+    NAVER(2, "네이버"),
+    GOOGLE(3, "구글"),
+    ANONYMOUS(4,"비회원");
+
+    private int number;
+    private String name;
+    Provider(int number, String name){
+        this.number = number;
+        this.name = name;
+    }
+
+    public static Provider getProviderByName(String name){
+        return Arrays.stream(Provider.values())
+                .filter(r -> r.getName().equals(name))
+                .findAny().orElse(null);
+    }
+    }

--- a/src/main/java/com/codepatissier/keki/user/repository/UserRepository.java
+++ b/src/main/java/com/codepatissier/keki/user/repository/UserRepository.java
@@ -1,5 +1,6 @@
 package com.codepatissier.keki.user.repository;
 
+import com.codepatissier.keki.user.entity.Provider;
 import com.codepatissier.keki.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -9,7 +10,10 @@ import java.util.Optional;
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
-    boolean existsByEmail(String email);
     boolean existsByNickname(String nickname);
     Optional<User> findByUserIdxAndStatusEquals(Long userIdx, String status);
+
+    boolean existsByEmailAndProvider(String email, Provider provider);
+
+    User findByEmailAndProvider(String email, Provider provider);
 }

--- a/src/main/java/com/codepatissier/keki/user/service/UserService.java
+++ b/src/main/java/com/codepatissier/keki/user/service/UserService.java
@@ -7,12 +7,11 @@ import com.codepatissier.keki.user.dto.*;
 import com.codepatissier.keki.user.entity.Provider;
 import com.codepatissier.keki.user.entity.User;
 import com.codepatissier.keki.user.repository.UserRepository;
-import com.github.scribejava.core.model.OAuth2AccessToken;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import javax.servlet.http.HttpSession;
+
 
 import static com.codepatissier.keki.common.BaseResponseStatus.*;
 
@@ -22,40 +21,12 @@ import static com.codepatissier.keki.common.BaseResponseStatus.*;
 public class UserService {
     private final UserRepository userRepository;
     private final AuthService authService;
-    private final KakaoService kakaoService;
-    private final NaverService naverService;
-    private final GoogleService googleService;
 
-    // 카카오 로그인
-    public PostUserRes kakaoLogin(String authorize_code) throws BaseException{
+    // 로그인
+    public PostUserRes login(String email, String provider) throws BaseException{
         try {
-            String kakaoToken = kakaoService.getAccessToken(authorize_code);
-            String userEmail = kakaoService.getUserInfo(kakaoToken);
-            return signInOrUp(userEmail, Provider.KAKAO);
-        } catch (BaseException e) {
-            throw e;
-        } catch (Exception e) {
-            throw new BaseException(DATABASE_ERROR);
-        }
-    }
-
-    // 네이버 로그인
-    public PostUserRes naverLogin(String code, HttpSession session) throws BaseException{
-        try{
-            OAuth2AccessToken naverToken = naverService.getAccessToken(session, code);
-            String userEmail = naverService.getUserInfo(naverToken);
-            return signInOrUp(userEmail, Provider.NAVER);
-        } catch (Exception e) {
-            throw new BaseException(DATABASE_ERROR);
-        }
-    }
-
-    // 구글 로그인
-    public PostUserRes googleLogin(String code, HttpSession session) throws BaseException{
-        try {
-            String googleToken = googleService.getAccessToken(session, code);
-            String userEmail = googleService.getUserInfo(googleToken);
-            return signInOrUp(userEmail, Provider.GOOGLE);
+            if(Provider.getProviderByName(provider) == null) throw new BaseException(INVALID_PROVIDER);
+            return signInOrUp(email, Provider.getProviderByName(provider));
         } catch (BaseException e) {
             throw e;
         } catch (Exception e) {
@@ -64,11 +35,11 @@ public class UserService {
     }
 
     // 회원가입 또는 기존 로그인
-    private PostUserRes signInOrUp(String userEmail, Provider provider) throws BaseException {
-        boolean is_user = userRepository.existsByEmail(userEmail);
+    private PostUserRes signInOrUp(String email, Provider provider) throws BaseException {
+        boolean is_user = userRepository.existsByEmailAndProvider(email, provider);
         User user;
-        if (!is_user) user = signup(userEmail, provider);
-        else user = userRepository.findByEmail(userEmail).orElseThrow(() -> new BaseException(INVALID_EMAIL));
+        if (!is_user) user = signup(email, provider);
+        else user = userRepository.findByEmailAndProvider(email, provider);
         return authService.createToken(user);
     }
 
@@ -80,16 +51,6 @@ public class UserService {
                 .role(Role.ANONYMOUS)
                 .build();
         return userRepository.save(newUser);
-    }
-
-    // 테스트 편리 위한 임시 로그인
-    public PostUserRes signinEmail(PostUserReq postUserReq) throws BaseException{
-        User user = userRepository.findByEmail(postUserReq.getEmail()).orElseThrow(() -> new BaseException(INVALID_EMAIL));
-        Long userIdx = user.getUserIdx();
-        String accessToken = authService.createAccessToken(userIdx);
-        String refreshToken = authService.createRefreshToken(userIdx);
-
-        return new PostUserRes(accessToken, refreshToken, user.getRole());
     }
 
     // 구매자 회원가입
@@ -165,4 +126,5 @@ public class UserService {
             throw new BaseException(DATABASE_ERROR);
         }
     }
+
 }


### PR DESCRIPTION
## 📚 이슈 번호
#8 

## 💬 기타 사항
- 서버에서 로그인 url 전송 -> 클라이언트에서 인증 및 이메일 추출 -> 회원가입 또는 로그인 및 토큰 응답
- Provider에 num과 name 추가
- 이전 카카오/네이버/구글 로그인 로직 수정
