### PR TITLE
[feature/9-histoires-union] 최근 검색어/게시물 에러 변경

### DIFF
--- a/src/main/java/com/codepatissier/keki/history/repository/PostHistoryRepositoryImpl.java
+++ b/src/main/java/com/codepatissier/keki/history/repository/PostHistoryRepositoryImpl.java
@@ -21,7 +21,7 @@ public class PostHistoryRepositoryImpl implements PostHistoryCustom {
         return jpaQueryFactory.selectFrom(postHistory)
                 .where(user.eq(userEntity))
                 .groupBy(post)
-                .orderBy(postHistory.createdDate.desc())
+                .orderBy(postHistory.lastModifiedDate.desc())
                 .limit(5)
                 .fetch();
     }

--- a/src/main/java/com/codepatissier/keki/history/repository/SearchHistoryRepositoryImpl.java
+++ b/src/main/java/com/codepatissier/keki/history/repository/SearchHistoryRepositoryImpl.java
@@ -34,7 +34,7 @@ public class SearchHistoryRepositoryImpl implements SearchHistoryCustom {
                         .and(searchHistory.status.eq(status)))
                 .groupBy(searchHistory.searchWord)
                 .limit(5)
-                .orderBy(searchHistory.createdDate.desc())
+                .orderBy(searchHistory.lastModifiedDate.desc())
                 .fetch();
     }
 }


### PR DESCRIPTION
## 📚 이슈 번호
#9

## 💬 기타 사항
- 예를 들어서 케이크 / 생일 /케이크 이렇게 검색하면 생일, 케이크로 지난 검색을 다시 검색하면 반영 안됨
- 위 상황에서 케이크 검색을 한 번 더하면 케이크, 생일 순으로 변경하도록 로직 변경