### PR TITLE
[feature/8-users-auth] redis 적용 및 액세스토큰 재발급 API 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 application-oauth.properties
+application-redis.properties
 HELP.md
 .gradle
 build/

--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,9 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.2'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.2'
 
+	// redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
 	// QueryDsl
 	implementation 'com.querydsl:querydsl-jpa'
 

--- a/src/main/java/com/codepatissier/keki/common/config/RedisConfig.java
+++ b/src/main/java/com/codepatissier/keki/common/config/RedisConfig.java
@@ -4,6 +4,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 
@@ -16,9 +17,16 @@ public class RedisConfig {
     @Value("${spring.redis.port}")
     private int port;
 
+    @Value("${spring.redis.password}")
+    private String password;
+
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {
-        return new LettuceConnectionFactory(host, port);
+        RedisStandaloneConfiguration redisStandaloneConfiguration = new RedisStandaloneConfiguration();
+        redisStandaloneConfiguration.setHostName(host);
+        redisStandaloneConfiguration.setPort(port);
+        redisStandaloneConfiguration.setPassword(password);
+        return new LettuceConnectionFactory(redisStandaloneConfiguration);
     }
 
     @Bean

--- a/src/main/java/com/codepatissier/keki/common/config/RedisConfig.java
+++ b/src/main/java/com/codepatissier/keki/common/config/RedisConfig.java
@@ -1,0 +1,30 @@
+package com.codepatissier.keki.common.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.redis.host}")
+    private String host;
+
+    @Value("${spring.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public RedisTemplate<?, ?> redisTemplate() {
+        RedisTemplate<?, ?> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        return redisTemplate;
+    }
+}

--- a/src/main/java/com/codepatissier/keki/user/controller/UserController.java
+++ b/src/main/java/com/codepatissier/keki/user/controller/UserController.java
@@ -130,4 +130,15 @@ public class UserController {
         }
     }
 
+    // AccessToken 재발급
+    @ResponseBody
+    @PostMapping("/reissue")
+    public BaseResponse<?> reissueToken(@RequestBody PostTokenReq postTokenReq) {
+        try{
+            return new BaseResponse<>(userService.reissueToken(postTokenReq));
+        }catch (BaseException e){
+            return new BaseResponse<>(e.getStatus());
+        }
+    }
+
 }

--- a/src/main/java/com/codepatissier/keki/user/dto/PostTokenReq.java
+++ b/src/main/java/com/codepatissier/keki/user/dto/PostTokenReq.java
@@ -1,0 +1,15 @@
+package com.codepatissier.keki.user.dto;
+
+import lombok.Getter;
+
+import javax.validation.constraints.NotBlank;
+
+@Getter
+public class PostTokenReq {
+    @NotBlank
+    private String email;
+    @NotBlank
+    private String provider;
+    @NotBlank
+    private String refreshToken;
+}

--- a/src/main/java/com/codepatissier/keki/user/repository/UserRepository.java
+++ b/src/main/java/com/codepatissier/keki/user/repository/UserRepository.java
@@ -11,7 +11,7 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByNickname(String nickname);
     Optional<User> findByUserIdxAndStatusEquals(Long userIdx, String status);
-    User findByEmailAndProviderAndStatusEquals(String email, Provider provider, String activeStatus);
-
     User findByEmailAndProvider(String email, Provider provider);
+
+    Optional<User> findByEmailAndProviderAndStatusEquals(String email, Provider provider, String status);
 }

--- a/src/main/java/com/codepatissier/keki/user/service/AuthService.java
+++ b/src/main/java/com/codepatissier/keki/user/service/AuthService.java
@@ -1,5 +1,6 @@
 package com.codepatissier.keki.user.service;
 
+import java.time.Duration;
 import java.util.Date;
 
 
@@ -13,6 +14,7 @@ import com.codepatissier.keki.user.entity.User;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
 import org.springframework.web.context.request.RequestContextHolder;
@@ -31,6 +33,8 @@ public class AuthService {
     // TODO 액세스토큰 만료시간 추후 줄이기 (테스트 위해 임시 설정)
     private final int accessTokenExpiryDate = 604800000;
     private final int refreshTokenExpiryDate = 604800000;
+
+    private final RedisTemplate<String, String> redisTemplate;
 
     @Value("${auth.key}")
     private String key;
@@ -91,6 +95,7 @@ public class AuthService {
                 .setExpiration(new Date(now.getTime() + refreshTokenExpiryDate))
                 .signWith(SignatureAlgorithm.HS256, key)
                 .compact();
+        redisTemplate.opsForValue().set(String.valueOf(userIdx), refreshToken, Duration.ofMillis(refreshTokenExpiryDate));
         return refreshToken;
     }
 

--- a/src/main/java/com/codepatissier/keki/user/service/AuthService.java
+++ b/src/main/java/com/codepatissier/keki/user/service/AuthService.java
@@ -110,4 +110,9 @@ public class AuthService {
         return accessToken;
     }
 
+    public String validateRefreshToken(Long userIdx, String refreshTokenReq) throws BaseException {
+        String refreshToken = (String) redisTemplate.opsForValue().get(String.valueOf(userIdx));
+        if(!refreshToken.equals(refreshTokenReq)) throw new BaseException(INVALID_TOKEN);
+        return refreshToken;
+    }
 }

--- a/src/main/java/com/codepatissier/keki/user/service/UserService.java
+++ b/src/main/java/com/codepatissier/keki/user/service/UserService.java
@@ -57,7 +57,7 @@ public class UserService {
     }
 
     // 구매자 회원가입
-    @Transactional // TODO @Transactional(rollbackFor = Exception.class) 수정
+    @Transactional(rollbackFor = Exception.class)
     public PostUserRes signupCustomer(Long userIdx, PostCustomerReq postCustomerReq) throws BaseException{
         try {
             User user = userRepository.findByUserIdxAndStatusEquals(userIdx, ACTIVE_STATUS).orElseThrow(() -> new BaseException(INVALID_USER_IDX));

--- a/src/main/java/com/codepatissier/keki/user/service/UserService.java
+++ b/src/main/java/com/codepatissier/keki/user/service/UserService.java
@@ -14,7 +14,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 
-
 import static com.codepatissier.keki.common.BaseResponseStatus.*;
 
 
@@ -22,7 +21,6 @@ import static com.codepatissier.keki.common.BaseResponseStatus.*;
 @RequiredArgsConstructor
 public class UserService {
     private final UserRepository userRepository;
-    private final StoreRepository storeRepository;
     private final AuthService authService;
 
     // 로그인

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -10,9 +10,5 @@ spring.jpa.database=mysql
 
 jasypt.encryptor.bean= jasyptStringEncryptor
 
-# oauth
-spring.profiles.include=oauth
-
-# redis
-spring.redis.host=localhost
-spring.redis.port=6379
+# oauth, redis
+spring.profiles.include=oauth, redis

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -12,4 +12,7 @@ jasypt.encryptor.bean= jasyptStringEncryptor
 
 # oauth
 spring.profiles.include=oauth
- 
+
+# redis
+spring.redis.host=localhost
+spring.redis.port=6379


### PR DESCRIPTION
## 📚 이슈 번호
#8

## 💬 기타 사항
- redis 설정 추가 _(회의에서 redis 서버 정한 후, host 주소는 변경하겠습니다) 완료_
- 회원가입 및 로그인 시, refreshToken redis에 저장
- accessToken 재발급 로직 추가 (유효한 accessToken인지 체크해야하는데, 이 부분은 프론트에서 이메일 넘겨줄 수 있는지 체크 필요)
- response로 회원가입 및 로그인 로직에서 사용한 PostUserRes(토큰들+역할)를 그대로 사용했는데, 새로 만들어서 쓰는게 나을지(토큰들) 그대로 사용하는게 좋을지 고민이 됩니다,,
- 선생님들 잠깐 출장 갔다가 출근했슴니다 대가로 더 열심히 해보겠슴니다 👻

