### PR TITLE
[feature/11-home-fix] 홈 api 수정

### DIFF
--- a/src/main/java/com/codepatissier/keki/calendar/DateCountCategory.java
+++ b/src/main/java/com/codepatissier/keki/calendar/DateCountCategory.java
@@ -4,25 +4,27 @@ import lombok.Getter;
 
 @Getter
 public enum DateCountCategory {
-    ONE_HUNDRED(100),
-    TWO_HUNDRED(200),
-    THREE_HUNDRED(300),
-    ONE_YEAR(365),
-    FOUR_HUNDRED(400),
-    FIVE_HUNDRED(500),
-    SIX_HUNDRED(600),
-    SEVEN_HUNDRED(700),
-    TWO_YEAR(730),
-    EIGHT_HUNDRED(800),
-    NINE_HUNDRED(900),
-    ONE_THOUSAND(1000),
-    THREE_YEAR(1095),
-    FOUR_YEAR(1460),
-    FIVE_YEAR(1825),
-    THO_THOUSAND(2000);
+    ONE_HUNDRED(100, "100일"),
+    TWO_HUNDRED(200, "200일"),
+    THREE_HUNDRED(300, "200일"),
+    ONE_YEAR(365, "1주년"),
+    FOUR_HUNDRED(400, "400일"),
+    FIVE_HUNDRED(500, "500일"),
+    SIX_HUNDRED(600, "600일"),
+    SEVEN_HUNDRED(700, "700일"),
+    TWO_YEAR(730, "2주년"),
+    EIGHT_HUNDRED(800, "800일"),
+    NINE_HUNDRED(900, "900일"),
+    ONE_THOUSAND(1000, "1000일"),
+    THREE_YEAR(1095, "3주년"),
+    FOUR_YEAR(1460, "4주년"),
+    FIVE_YEAR(1825, "5주년"),
+    THO_THOUSAND(2000, "200일");
     private int count;
+    private String date;
 
-    DateCountCategory(int count){
+    DateCountCategory(int count, String date){
         this.count = count;
+        this.date = date;
     }
 }

--- a/src/main/java/com/codepatissier/keki/calendar/DateCountCategory.java
+++ b/src/main/java/com/codepatissier/keki/calendar/DateCountCategory.java
@@ -1,0 +1,28 @@
+package com.codepatissier.keki.calendar;
+
+import lombok.Getter;
+
+@Getter
+public enum DateCountCategory {
+    ONE_HUNDRED(100),
+    TWO_HUNDRED(200),
+    THREE_HUNDRED(300),
+    ONE_YEAR(365),
+    FOUR_HUNDRED(400),
+    FIVE_HUNDRED(500),
+    SIX_HUNDRED(600),
+    SEVEN_HUNDRED(700),
+    TWO_YEAR(730),
+    EIGHT_HUNDRED(800),
+    NINE_HUNDRED(900),
+    ONE_THOUSAND(1000),
+    THREE_YEAR(1095),
+    FOUR_YEAR(1460),
+    FIVE_YEAR(1825),
+    THO_THOUSAND(2000);
+    private int count;
+
+    DateCountCategory(int count){
+        this.count = count;
+    }
+}

--- a/src/main/java/com/codepatissier/keki/calendar/contoller/CalendarController.java
+++ b/src/main/java/com/codepatissier/keki/calendar/contoller/CalendarController.java
@@ -119,8 +119,8 @@ public class CalendarController {
             }
             // 아닌 경우에는 가장 가까운 기념일을 불러오고
             HomeRes home = this.calendarService.getHomeCalendar(this.authService.getUserIdx());
-            // 기념일의 태그가 3개 미만이면 다 랜덤으로 불러오고
-            // 태그가 3개 이상이면 태그별로 랜덤하게 불러오기
+            // 기념일의 태그가 없으면 랜덤으로
+            // 아니면 기념일 태그의 게시물만
             return new BaseResponse<>(this.calendarService.getHomeTagPost(home));
         } catch (BaseException e) {
             return new BaseResponse<>(e.getStatus());

--- a/src/main/java/com/codepatissier/keki/calendar/dto/CalendarDateReturn.java
+++ b/src/main/java/com/codepatissier/keki/calendar/dto/CalendarDateReturn.java
@@ -1,0 +1,14 @@
+package com.codepatissier.keki.calendar.dto;
+
+import com.codepatissier.keki.calendar.DateCountCategory;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class CalendarDateReturn {
+    private int calDate;
+    private DateCountCategory dateCountCategory;
+}

--- a/src/main/java/com/codepatissier/keki/calendar/dto/HomeRes.java
+++ b/src/main/java/com/codepatissier/keki/calendar/dto/HomeRes.java
@@ -1,5 +1,7 @@
 package com.codepatissier.keki.calendar.dto;
 
+import com.codepatissier.keki.calendar.entity.Calendar;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.querydsl.core.annotations.QueryProjection;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -17,4 +19,6 @@ public class HomeRes {
     private String calendarTitle;
     private int calendarDate;
     private List<HomeTagRes> homeTagResList;
+    @JsonIgnore
+    private Calendar calendar;
 }

--- a/src/main/java/com/codepatissier/keki/calendar/repository/CalendarTag/CalendarTagCustom.java
+++ b/src/main/java/com/codepatissier/keki/calendar/repository/CalendarTag/CalendarTagCustom.java
@@ -3,6 +3,7 @@ package com.codepatissier.keki.calendar.repository.CalendarTag;
 import com.codepatissier.keki.calendar.dto.PopularTagRes;
 import com.codepatissier.keki.user.entity.User;
 
+import java.util.Calendar;
 import java.util.List;
 
 public interface CalendarTagCustom {

--- a/src/main/java/com/codepatissier/keki/calendar/repository/CalendarTag/CalendarTagRepositoryImpl.java
+++ b/src/main/java/com/codepatissier/keki/calendar/repository/CalendarTag/CalendarTagRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.codepatissier.keki.calendar.repository.CalendarTag;
 
 import com.codepatissier.keki.calendar.dto.PopularTagRes;
 import com.codepatissier.keki.calendar.dto.QPopularTagRes;
+import com.codepatissier.keki.calendar.entity.Calendar;
 import com.codepatissier.keki.common.Constant;
 import com.codepatissier.keki.user.entity.User;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -35,6 +36,7 @@ public class CalendarTagRepositoryImpl implements CalendarTagCustom {
 
     /**
      * 사용자 별 인기 Tag 3개
+     * 다음에 쓸수 있으니, 혹시 몰라서 지우지 않고 남겨둘게요!
      */
     @Override
     public List<PopularTagRes> getPopularCalendarTagByUser(User userEntity) {
@@ -51,4 +53,5 @@ public class CalendarTagRepositoryImpl implements CalendarTagCustom {
                 .limit(Constant.Home.HOME_RETURN_TAG_COUNT)
                 .fetch();
     }
+
 }

--- a/src/main/java/com/codepatissier/keki/calendar/service/CalendarService.java
+++ b/src/main/java/com/codepatissier/keki/calendar/service/CalendarService.java
@@ -243,9 +243,9 @@ public class CalendarService {
                 // 날짜 계산
                 day = this.calculateDate(calendar);
                 if(calendar.getCalendarCategory().equals(CalendarCategory.DATE_COUNT)) day--; // 값을 하나 빼줌
-                return new HomeRes(user.getUserIdx(), user.getNickname(), calendar.getCalendarTitle(), Math.abs(day), null);
+                return new HomeRes(user.getUserIdx(), user.getNickname(), calendar.getCalendarTitle(), Math.abs(day), null, calendar);
             }
-            return new HomeRes(user.getUserIdx(), user.getNickname(), null, 0, null);
+            return new HomeRes(user.getUserIdx(), user.getNickname(), null, 0, null, null);
         }catch (Exception e){
             throw new BaseException(BaseResponseStatus.DATABASE_ERROR);
         }
@@ -257,7 +257,7 @@ public class CalendarService {
     public HomeRes getHomeCalendarAndPostLogout() throws BaseException{
         try{
             return new HomeRes(null, null, null, 0,
-                    getPostByTag(this.calendarTagRepository.getPopularCalendarTag()));
+                    getPostByTag(this.calendarTagRepository.getPopularCalendarTag()),null);
         }catch (Exception e){
             throw new BaseException(BaseResponseStatus.DATABASE_ERROR);
         }
@@ -266,11 +266,11 @@ public class CalendarService {
 
     // home api
     public HomeRes getHomeTagPost(HomeRes home) throws BaseException{
-        User user = this.findUserByUserIdx(home.getUserIdx());
         try{
-            List<PopularTagRes> tags = this.calendarTagRepository.getPopularCalendarTagByUser(user);
+            List<PopularTagRes> tags = this.calendarTagRepository.findByCalendarAndStatus(home.getCalendar(), ACTIVE_STATUS).stream()
+                    .map(cal -> new PopularTagRes(cal.getTag().getTagIdx(), cal.getTag().getTagName())).collect(Collectors.toList());
             // 기념일의 태그가 3개 미만이면 다 랜덤으로 불러오고
-            if(tags.size()< Constant.Home.HOME_RETURN_TAG_COUNT){
+            if(tags.size()==0){
                 home.setHomeTagResList(this.getPostByTag(this.calendarTagRepository.getPopularCalendarTag()));
             }else{ // 태그가 3개 이상이면 태그별로 랜덤하게 불러오기
                 home.setHomeTagResList(this.getPostByTag(tags));

--- a/src/main/java/com/codepatissier/keki/calendar/service/CalendarService.java
+++ b/src/main/java/com/codepatissier/keki/calendar/service/CalendarService.java
@@ -145,9 +145,9 @@ public class CalendarService {
     // 날짜 수 기념일 계산 (100일, 200일, 300일 등등)
     // 현재 2000일 미만으로 불러오도록 생성
     private CalendarDateReturn calculateDateForDateCount(Calendar cal) {
-        int day = this.calculateDate(cal); // 날짜수를 구해서
+        int day = this.calculateDate(cal) - 1; // 날짜수를 구함 -> 기존에 +1 을 해서 return 하기 때문에 +1을 해줌
         for(DateCountCategory count: DateCountCategory.values()){
-            if(day < count.getCount()) return new CalendarDateReturn(count.getCount()-day, count);
+            if(day <= count.getCount()) return new CalendarDateReturn(count.getCount()-day, count);
         }
         return new CalendarDateReturn(day, null);
     }
@@ -236,13 +236,12 @@ public class CalendarService {
                 if (calDateReturn.getCalDate()<Math.abs(day) && calDateReturn.getDateCountCategory() != null) {
                     calendar = cal;
                     calendar.setCalendarTitle(calendar.getCalendarTitle()+"의 " + calDateReturn.getDateCountCategory().getDate());
+                    day = calDateReturn.getCalDate();
                 }
             }
 
             if(calendar != null){
                 // 날짜 계산
-                day = this.calculateDate(calendar);
-                if(calendar.getCalendarCategory().equals(CalendarCategory.DATE_COUNT)) day--; // 값을 하나 빼줌
                 return new HomeRes(user.getUserIdx(), user.getNickname(), calendar.getCalendarTitle(), Math.abs(day), null, calendar);
             }
             return new HomeRes(user.getUserIdx(), user.getNickname(), null, 0, null, null);

--- a/src/main/java/com/codepatissier/keki/calendar/service/CalendarService.java
+++ b/src/main/java/com/codepatissier/keki/calendar/service/CalendarService.java
@@ -235,7 +235,7 @@ public class CalendarService {
                 CalendarDateReturn calDateReturn = this.calculateDateForDateCount(cal);
                 if (calDateReturn.getCalDate()<Math.abs(day) && calDateReturn.getDateCountCategory() != null) {
                     calendar = cal;
-                    calendar.setCalendarTitle(calendar.getCalendarTitle()+"의 " + calDateReturn.getDateCountCategory().getCount() + "일");
+                    calendar.setCalendarTitle(calendar.getCalendarTitle()+"의 " + calDateReturn.getDateCountCategory().getDate());
                 }
             }
 


### PR DESCRIPTION
## 📚 이슈 번호
#11

## 💬 기타 사항
- 홈 api 에러 해결
- 기념일이 날짜 수 인 경우 "기념일 제목의 100(200, 300 ~~~)일이 00일 남았어요" 으로 처리 완료
- 사용자별 인기 태그가 3개 이하인 경우 랜덤으로 불러오던 것들을 기념일 별 태그 게시물로 변경
