### PR TITLE
[feature/7-desserts-getone-fix] 상품 상세 조회 API images 리턴값 상품 상세 이미지(1장)+피드 대표 이미지(최대 4장)로 수정

### DIFF
--- a/src/main/java/com/codepatissier/keki/dessert/dto/GetDessertRes.java
+++ b/src/main/java/com/codepatissier/keki/dessert/dto/GetDessertRes.java
@@ -21,7 +21,7 @@ public class GetDessertRes {
     @AllArgsConstructor
     @NoArgsConstructor
     public static class Image {
-        private Long postIdx;
-        private String postImgUrl;
+        private Long imgIdx;
+        private String imgUrl;
     }
 }

--- a/src/main/java/com/codepatissier/keki/dessert/service/DessertService.java
+++ b/src/main/java/com/codepatissier/keki/dessert/service/DessertService.java
@@ -15,6 +15,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -80,9 +81,12 @@ public class DessertService {
         try {
             Dessert dessert = dessertRepository.findByDessertIdxAndStatus(dessertIdx, ACTIVE_STATUS).orElseThrow(() -> new BaseException(INVALID_DESSERT_IDX));
 
-            List<GetDessertRes.Image> imgList = getPostImgList(dessert);
+            ArrayList<GetDessertRes.Image> imgList = new ArrayList<>();
+            imgList.add(getDessertImg(dessert));
+            ArrayList<GetDessertRes.Image> postImgList = getPostImgList(dessert);
+            imgList.addAll(postImgList);
 
-            // nickname, dessertName, dessertPrice, dessertDescription, imgList
+            // nickname, dessertName, dessertPrice, dessertDescription, imgList(상품 상세 이미지 1장, 피드 이미지 4장)
             return new GetDessertRes(dessert.getStore().getUser().getNickname(), dessert.getDessertName(), dessert.getDessertPrice(), dessert.getDessertDescription(), imgList);
         } catch (BaseException e) {
             throw e;
@@ -91,9 +95,13 @@ public class DessertService {
         }
     }
 
-    // 특정 dessert가 들어간 post 5개를 가져와 postIdx와 대표 postImg를 반환
-    private List<GetDessertRes.Image> getPostImgList(Dessert dessert) {
-        return postRepository.findTop5ByDessertAndStatusOrderByPostIdxDesc(dessert, ACTIVE_STATUS).stream()
+    private GetDessertRes.Image getDessertImg(Dessert dessert) {
+        return new GetDessertRes.Image(dessert.getDessertIdx(), dessert.getDessertImg());
+    }
+
+    // 특정 dessert가 들어간 post 4개를 가져와 postIdx와 대표 postImg를 반환
+    private ArrayList<GetDessertRes.Image> getPostImgList(Dessert dessert) {
+        return (ArrayList<GetDessertRes.Image>) postRepository.findTop4ByDessertAndStatusOrderByPostIdxDesc(dessert, ACTIVE_STATUS).stream()
                 .map(posts -> new GetDessertRes.Image(posts.getPostIdx(),
                         representPostImgUrl(posts.getImages()))).collect(Collectors.toList());
     }

--- a/src/main/java/com/codepatissier/keki/post/repository/PostRepository.java
+++ b/src/main/java/com/codepatissier/keki/post/repository/PostRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Repository
@@ -21,7 +22,7 @@ public interface PostRepository extends JpaRepository<Post, Long>, PostCustom {
 
     boolean existsByStoreAndStatusAndPostIdxLessThan(Store store, String status, Long postIdx);
     boolean existsByDessertDessertNameContainingAndStatusAndPostIdxLessThan(String word, String status, Long postIdx);
-    List<Post> findTop5ByDessertAndStatusOrderByPostIdxDesc(Dessert dessert, String activeStatus);
+    ArrayList<Post> findTop4ByDessertAndStatusOrderByPostIdxDesc(Dessert dessert, String activeStatus);
 
     void deleteByDessert(Dessert dessert);
 }


### PR DESCRIPTION
## 📚 이슈 번호
#7

## 💬 기타 사항
- images [{imgIdx, imgUrl}, {imgIdx, imgUrl}, ...] 형식으로 변경
- 첫 이미지는 상품 상세 이미지로 고정, 피드 대표 이미지는 해당 디저트가 올라간 피드 개수에 따라 최대 4개까지
