### PR TITLE
[feature/8-users-auth] 로그아웃 api 토큰 관리 추가

### DIFF
--- a/src/main/java/com/codepatissier/keki/common/BaseResponseStatus.java
+++ b/src/main/java/com/codepatissier/keki/common/BaseResponseStatus.java
@@ -14,11 +14,12 @@ public enum BaseResponseStatus {
      *  2000: Request 오류
      */
     // users(2000~2099)
-     NULL_TOKEN(false, 2000, "토큰 값을 입력해주세요."),
+    NULL_TOKEN(false, 2000, "토큰 값을 입력해주세요."),
     NULL_EMAIL(false, 2001, "이메일을 입력해주세요."),
     NULL_PROVIDER(false, 2002, "소셜 이름을 입력해주세요."),
     INVALID_PROVIDER(false, 2003, "잘못된 소셜 이름입니다."),
-    ALREADY_WITHDRAW_USER(false, 2003, "이미 삭제된 회원입니다."),
+    ALREADY_WITHDRAW_USER(false, 2004, "이미 삭제된 회원입니다."),
+    INVALID_TOKEN(false, 2005, "유효하지 않은 토큰 값입니다."),
 
     // stores(2100~2199)
     NULL_ADDRESS(false, 2100, "주소를 입력해주세요."),
@@ -68,8 +69,7 @@ public enum BaseResponseStatus {
     INVALID_EMAIL(false, 3002, "존재하지 않는 이메일입니다."),
     NO_STORE_ROLE(false, 3003, "판매자가 아닙니다."),
     INVALID_USER_STATUS(false, 3004, "비활성화된 사용자입니다."),
-    INVALID_TOKEN(false, 3005, "잘못된 토큰 값입니다."),
-    EXPIRED_TOKEN(false, 3006, "만료된 토큰 값입니다."),
+    EXPIRED_TOKEN(false, 3005, "만료된 토큰 값입니다."),
 
     // stores(3100~3199)
     INVALID_STORE_IDX(false, 3100, "존재하지 않는 스토어입니다."),

--- a/src/main/java/com/codepatissier/keki/store/service/StoreService.java
+++ b/src/main/java/com/codepatissier/keki/store/service/StoreService.java
@@ -31,7 +31,7 @@ public class StoreService {
             String refreshToken = authService.createRefreshToken(userIdx);
 
             User user = userRepository.findByUserIdxAndStatusEquals(userIdx, Constant.ACTIVE_STATUS).orElseThrow(() -> new BaseException(INVALID_USER_IDX));
-            user.storeSignUp(postStoreReq.getNickname(), postStoreReq.getStoreImgUrl(), refreshToken, Role.STORE);
+            user.storeSignUp(postStoreReq.getNickname(), postStoreReq.getStoreImgUrl(), Role.STORE);
             userRepository.save(user);
 
             Store store = Store.builder()

--- a/src/main/java/com/codepatissier/keki/user/entity/User.java
+++ b/src/main/java/com/codepatissier/keki/user/entity/User.java
@@ -36,8 +36,6 @@ public class User extends BaseEntity {
     @Column(length = 300)
     private String profileImg;
 
-    private String refreshToken;
-
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private Role role;
@@ -49,9 +47,8 @@ public class User extends BaseEntity {
         this.role = role;
     }
 
-    public void signup(String nickname, String refreshToken, Role role, String profileImg) {
+    public void signup(String nickname, Role role, String profileImg) {
         this.nickname = nickname;
-        this.refreshToken = refreshToken;
         this.role = role;
         this.profileImg = profileImg;
     }
@@ -60,10 +57,9 @@ public class User extends BaseEntity {
         return this.role.getName();
     }
 
-    public void storeSignUp(String nickname, String profileImg, String refreshToken, Role role) {
+    public void storeSignUp(String nickname, String profileImg, Role role) {
         this.nickname = nickname;
         this.profileImg = profileImg;
-        this.refreshToken = refreshToken;
         this.role = role;
     }
     
@@ -89,7 +85,6 @@ public class User extends BaseEntity {
         this.email = "anonymous@keki.store";
         this.provider = Provider.ANONYMOUS;
         this.profileImg = null;
-        this.refreshToken = null;
         this.role = Role.ANONYMOUS;
         this.setStatus(Constant.INACTIVE_STATUS);
         // TODO status enum으로 변경
@@ -97,7 +92,6 @@ public class User extends BaseEntity {
 
     // 회원 로그아웃
     public void logout() {
-        this.refreshToken = null;
         this.setStatus(Constant.LOGOUT_STATUS);
     }
 

--- a/src/main/java/com/codepatissier/keki/user/service/UserService.java
+++ b/src/main/java/com/codepatissier/keki/user/service/UserService.java
@@ -64,7 +64,7 @@ public class UserService {
             String accessToken = authService.createAccessToken(userIdx);
             String refreshToken = authService.createRefreshToken(userIdx);
 
-            user.signup(postCustomerReq.getNickname(),Role.CUSTOMER, postCustomerReq.getProfileImg());
+            user.signup(postCustomerReq.getNickname(), Role.CUSTOMER, postCustomerReq.getProfileImg());
             userRepository.save(user);
 
             return new PostUserRes(accessToken, refreshToken, user.getRole());
@@ -120,8 +120,8 @@ public class UserService {
     public void logout(Long userIdx) throws BaseException {
         try{
             User user = userRepository.findByUserIdxAndStatusEquals(userIdx, ACTIVE_STATUS).orElseThrow(() -> new BaseException(INVALID_USER_IDX));
+            authService.logout(userIdx);
             user.logout();
-            // TODO redis 사용해 토큰 관리
         } catch (BaseException e) {
             throw e;
         } catch (Exception e) {

--- a/src/main/java/com/codepatissier/keki/user/service/UserService.java
+++ b/src/main/java/com/codepatissier/keki/user/service/UserService.java
@@ -64,7 +64,7 @@ public class UserService {
             String accessToken = authService.createAccessToken(userIdx);
             String refreshToken = authService.createRefreshToken(userIdx);
 
-            user.signup(postCustomerReq.getNickname(), refreshToken, Role.CUSTOMER, postCustomerReq.getProfileImg());
+            user.signup(postCustomerReq.getNickname(),Role.CUSTOMER, postCustomerReq.getProfileImg());
             userRepository.save(user);
 
             return new PostUserRes(accessToken, refreshToken, user.getRole());


### PR DESCRIPTION
## 📚 이슈 번호
#8

## 💬 기타 사항
- User에서 refreshToken 컬럼을 삭제하고 전부 redis에 저장하도록 수정
- 로그아웃 API에서 redis 활용해 토큰 관리하도록 추가 !
